### PR TITLE
Keep description visible for audio documents

### DIFF
--- a/src/widget/javascript.js
+++ b/src/widget/javascript.js
@@ -143,7 +143,7 @@ function setup() {
       const forwardMouseEvent = (e, type) => {
         const target = pickTarget(e.clientX, e.clientY);
         if (!target) return;
-        
+
         const init = {
           bubbles: true,
           cancelable: true,

--- a/src/widget/javascript.js
+++ b/src/widget/javascript.js
@@ -535,6 +535,15 @@ function setup() {
         return;
       }
 
+      // Check if current document is audio format
+      const currentFormat = this.getCurrentFormat().toLowerCase();
+      const isAudioFormat = currentFormat.startsWith('audio/');
+      
+      // Don't set timeout for audio documents - they stay visible like showAsLink documents
+      if (isAudioFormat) {
+        return;
+      }
+
       this.hideFileNameTimeout = setTimeout(() => {
         this.descriptionDisplay.classList.add("fade-out");
         setTimeout(() => {


### PR DESCRIPTION
## Summary

This PR enhances the user experience for audio documents by keeping the description permanently visible, similar to how `showAsLink` documents behave.

## Changes Made

### Enhanced Description Visibility
- Modified `showDocumentDescription()` method to detect audio formats
- Audio document descriptions now stay visible permanently (no 5-second auto-hide)
- Consistent behavior with `showAsLink` documents for better UX

### Technical Implementation
- Added audio format detection using `getCurrentFormat().toLowerCase().startsWith('audio/')`
- Early return prevents timeout setup for audio documents
- Maintains existing auto-hide behavior for all other document types

## Rationale

Audio players are compact and don't conflict with the description display area. Unlike full-screen document viewers, audio players occupy minimal space, making it beneficial to keep descriptions visible for:
- Track information
- Audio metadata
- User context and navigation

## Files Modified
- `src/widget/javascript.js`: Enhanced `showDocumentDescription()` method

## Testing
- Verified audio documents keep descriptions visible
- Confirmed other document types maintain auto-hide behavior
- Tested with various audio formats (MP3, WAV, OGG, WebM)

## Link to Devin run
https://app.devin.ai/sessions/9d89949b14c74f3a96c9e50dc8aa4aa8

## Requested by
yevhen.porechnyi@corezoid.com