### PR TITLE
Add CSS rule for viewer-toolbar padding

### DIFF
--- a/src/widget/css.js
+++ b/src/widget/css.js
@@ -117,6 +117,10 @@ data.css = `
         scale: 1.3;
       }
 
+      .viewer-toolbar ul {
+        padding-bottom: 8px !important;
+      }
+
       .viewer-toolbar li {
         background-color: rgba(128, 128, 128, 0.8);
       }


### PR DESCRIPTION
## Summary

This PR adds a CSS rule for the viewer-toolbar ul element to improve the visual appearance of the widget.

## Changes Made

- Added `.viewer-toolbar ul { padding-bottom: 8px !important; }` CSS rule to src/widget/css.js
- Placed the rule near the existing viewer-toolbar selector

## Testing

- Widget builds successfully
- Visual appearance of the toolbar is improved with proper padding

## Link to Devin run
https://app.devin.ai/sessions/9d89949b14c74f3a96c9e50dc8aa4aa8

Requested by: yevhen.porechnyi@corezoid.com