### PR TITLE
Add toggle description button functionality

### DIFF
--- a/src/widget/css.js
+++ b/src/widget/css.js
@@ -1,4 +1,8 @@
 data.css = `
+      :root {
+        --brandColor: #F88010;
+      }
+
       .hidden {
         display: none !important;
       }
@@ -279,10 +283,16 @@ data.css = `
         background: rgba(0, 0, 0, 0.7);
       }
 
-      .fullscreen-btn {
+      .control-buttons-container {
         position: absolute;
         bottom: 10px;
-        right: var(--fullscreen-btn-right, 10px);
+        right: 10px;
+        display: flex;
+        gap: 5px;
+        z-index: 1000;
+      }
+
+      .fullscreen-btn {
         width: 32px;
         height: 32px;
         border-radius: 50%;
@@ -292,7 +302,6 @@ data.css = `
         display: flex;
         align-items: center;
         justify-content: center;
-        z-index: 1000;
         transition: opacity 0.3s ease, background-color 0.15s;
         opacity: 1;
       }
@@ -307,6 +316,43 @@ data.css = `
       }
 
       .fullscreen-btn svg {
+        width: 16px;
+        height: 16px;
+        fill: white;
+      }
+
+      .toggle-description-btn {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: rgba(128, 128, 128, 0.8);
+        border: none;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: opacity 0.3s ease, background-color 0.15s;
+        opacity: 1;
+      }
+
+      .toggle-description-btn:hover {
+        background: rgba(0, 0, 0, 0.7);
+      }
+
+      .toggle-description-btn.fade-out {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .toggle-description-btn.enabled {
+        background: var(--brandColor);
+      }
+
+      .toggle-description-btn.enabled:hover {
+        background: color-mix(in srgb, var(--brandColor) 90%, black);
+      }
+
+      .toggle-description-btn svg {
         width: 16px;
         height: 16px;
         fill: white;

--- a/src/widget/html.js
+++ b/src/widget/html.js
@@ -38,11 +38,19 @@ data.html = `<!DOCTYPE html>
 
     <div id="descriptionDisplay" class="description-display hidden"></div>
 
-    <button id="fullscreenBtn" class="fullscreen-btn hidden">
-      <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-        <path d="M10 15H15V10H13.2V13.2H10V15ZM6 15V13.2H2.8V10H1V15H6ZM10 2.8H12.375H13.2V6H15V1H10V2.8ZM6 1V2.8H2.8V6H1V1H6Z" />
-      </svg>
-    </button>
+    <div id="controlButtonsContainer" class="control-buttons-container">
+      <button id="toggleDescriptionBtn" class="toggle-description-btn">
+        <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+          <path d="M109.5 95.2C99.3 103 87.7 112 87.7 134.6h24.8c0-13.6 8.8-21.3 17.9-29.2 9.5-8.3 19.3-16.9 19.3-32.8a49.6 49.6 0 1 0-99.2 0h24.8c0-13.6 11.2-24.8 24.8-24.8s24.8 11.2 24.8 24.8c0 10.9-7.2 16.4-15.3 22.6Zm2.9 82.8v-24.8H87.6V178h24.8Z" />
+        </svg>
+      </button>
+
+      <button id="fullscreenBtn" class="fullscreen-btn hidden">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+          <path d="M10 15H15V10H13.2V13.2H10V15ZM6 15V13.2H2.8V10H1V15H6ZM10 2.8H12.375H13.2V6H15V1H10V2.8ZM6 1V2.8H2.8V6H1V1H6Z" />
+        </svg>
+      </button>
+    </div>
 
     <script>
 		${javaScript}

--- a/test/test-page.js
+++ b/test/test-page.js
@@ -51,7 +51,8 @@ function addSampleDocuments() {
         {
             url: basePath + "file_example_MP3_700KB.mp3",
             description: "Аудио файл (MP3)",
-            format: "audio/mpeg"
+            format: "audio/mpeg",
+            showAsLink: true
         },
         {
             url: "/assets/sample.pdf",


### PR DESCRIPTION
## Summary

This PR adds a toggle description button functionality to the document viewer widget.

## Changes Made

- **Added toggle description button** with question mark icon next to the fullscreen button
- **Implemented showDescriptionEnabled state management** to control description visibility
- **Created shared control buttons container** with flex layout and 5px gap
- **Added orange brand color (#F88010)** for enabled button state with color-mix hover effects
- **Updated description display logic** to respect toggle state while maintaining link display for showAsLink documents
- **Added proper fade-out animations** for both fullscreen and toggle description buttons
- **Maintained backward compatibility** with existing description behavior

## Technical Details

- Button uses the provided question mark SVG icon
- Orange brand color defined as CSS custom property --brandColor: #F88010
- Hover effects use color-mix() function for proper color darkening
- Description logic respects both global toggle state and document-specific overrides
- Proper fade-out timing maintained for UI consistency

## Testing

- Toggle button appears and functions correctly
- Description shows/hides based on button state
- Button styling (orange when enabled, gray when disabled) works as expected
- Existing functionality for showAsLink documents preserved
- Fade-out animations work properly for both buttons

Link to Devin run: https://app.devin.ai/sessions/d50b284a5d5145618ae8da0434d55d48
Requested by: yevhen.porechnyi@corezoid.com