### PR TITLE
Fix module cache clearing in builder.js

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -68,8 +68,10 @@ function buildWidget() {
 
   try {
     console.log('📝 Processing CSS component...');
-    delete require.cache[path.join(componentsDir, 'css.js')];
-    require(path.join(componentsDir, 'css.js'));
+    const cssModule = path.join(componentsDir, 'css.js');
+    const cssKey = require.resolve(cssModule);
+    delete require.cache[cssKey];
+    require(cssKey);
   } catch (error) {
     generateErrorPage('CSS', error, distDir);
     buildSuccess = false;
@@ -78,8 +80,10 @@ function buildWidget() {
   if (buildSuccess) {
     try {
       console.log('⚡ Processing JavaScript component...');
-      delete require.cache[path.join(componentsDir, 'javascript.js')];
-      require(path.join(componentsDir, 'javascript.js'));
+      const jsModule = path.join(componentsDir, 'javascript.js');
+      const jsKey = require.resolve(jsModule);
+      delete require.cache[jsKey];
+      require(jsKey);
     } catch (error) {
       generateErrorPage('JavaScript', error, distDir);
       buildSuccess = false;
@@ -89,8 +93,10 @@ function buildWidget() {
   if (buildSuccess) {
     try {
       console.log('🏗️  Processing HTML component...');
-      delete require.cache[path.join(componentsDir, 'html.js')];
-      require(path.join(componentsDir, 'html.js'));
+      const htmlModule = path.join(componentsDir, 'html.js');
+      const htmlKey = require.resolve(htmlModule);
+      delete require.cache[htmlKey];
+      require(htmlKey);
     } catch (error) {
       generateErrorPage('HTML', error, distDir);
       buildSuccess = false;


### PR DESCRIPTION
## Fix module cache clearing in builder.js

This PR fixes the module cache clearing logic in `src/builder.js` that was causing build failures during development.

### Problem

The original code used `path.join()` to construct cache keys for `delete require.cache[...]`, but Node.js stores modules in `require.cache` using absolute paths returned by `require.resolve()`. This mismatch meant that cache entries were never actually cleared, causing stale module data during rebuilds.

### Solution

- Replace `path.join()` with `require.resolve()` to get the correct cache keys
- Apply this fix to all three component modules: `css.js`, `javascript.js`, and `html.js`

### Technical Details

```javascript
// Before (incorrect)
delete require.cache[path.join(componentsDir, 'css.js')];

// After (correct)
const cssModule = path.join(componentsDir, 'css.js');
const cssKey = require.resolve(cssModule);
delete require.cache[cssKey];
```

### Testing

- ✅ Development server now correctly rebuilds widgets when component files are modified
- ✅ File watcher triggers proper cache clearing and module reloading
- ✅ No more stale data issues during development

Link to Devin run: https://app.devin.ai/sessions/d50b284a5d5145618ae8da0434d55d48
Requested by: yevhen.porechnyi@corezoid.com