### PR TITLE
Fix description positioning for viewerJS slides

### DIFF
--- a/src/widget/css.js
+++ b/src/widget/css.js
@@ -229,7 +229,7 @@ data.css = `
 
       .description-display {
         position: absolute;
-        bottom: 50px;
+        bottom: 10px;
         left: 50%;
         transform: translateX(-50%);
         background: rgba(0, 0, 0, 0.7);
@@ -251,6 +251,10 @@ data.css = `
         display: flex;
         flex-direction: column;
         gap: 10px;
+      }
+
+      .description-display.shift-up {
+        bottom: 50px;
       }
 
       .description-display.fade-out {

--- a/src/widget/javascript.js
+++ b/src/widget/javascript.js
@@ -484,6 +484,19 @@ function script(documents, config) {
       this.descriptionDisplay.className = "description-display";
       this.descriptionDisplay.classList.remove("hidden", "fade-out");
 
+      // Check if current document uses viewerJS (image formats)
+      const documentFormat = this.getCurrentFormat().toLowerCase();
+      const isViewerJSFormat = [
+        "image/gif", "image/jpg", "image/jpeg", "image/png", 
+        "image/svg+xml", "image/bmp", "image/webp"
+      ].includes(documentFormat);
+
+      if (isViewerJSFormat) {
+        this.descriptionDisplay.classList.add("shift-up");
+      } else {
+        this.descriptionDisplay.classList.remove("shift-up");
+      }
+
       if (currentDoc.showAsLink) {
         this.descriptionDisplay.classList.add("show-as-link");
       } else {
@@ -528,8 +541,8 @@ function script(documents, config) {
       }
 
       // Check if current document is audio format
-      const currentFormat = this.getCurrentFormat().toLowerCase();
-      const isAudioFormat = currentFormat.startsWith('audio/');
+      const audioFormat = this.getCurrentFormat().toLowerCase();
+      const isAudioFormat = audioFormat.startsWith('audio/');
 
       // Don't set timeout for audio documents when description is enabled
       if (isAudioFormat) {


### PR DESCRIPTION
## Fix description positioning for viewerJS slides

This PR implements the requested changes to description positioning logic:

### Changes Made
- Changed default `.description-display` bottom margin from 50px to 10px
- Added `.shift-up` class with 50px bottom margin for viewerJS formats
- Implemented automatic detection of viewerJS formats (gif, jpg, jpeg, png, svg, bmp, webp)
- Apply `.shift-up` class for image documents, remove for others
- Fixed variable naming conflicts in showDocumentDescription function

### Technical Details
- **CSS changes**: Modified `src/widget/css.js` to adjust default positioning and add shift-up class
- **JavaScript changes**: Updated `src/widget/javascript.js` to detect viewerJS formats and apply appropriate styling
- **Format detection**: Uses `getCurrentFormat()` to identify image formats that use viewerJS
- **Class management**: Automatically adds/removes `.shift-up` class based on document type

### Testing
- ✅ Non-image documents show description 10px from bottom (default)
- ✅ Image documents show description 50px from bottom (shift-up applied)
- ✅ Switching between document types properly resets the class
- ✅ No regressions in showAsLink or audio document behavior

Link to Devin run: https://app.devin.ai/sessions/d50b284a5d5145618ae8da0434d55d48
Requested by: yevhen.porechnyi@corezoid.com