### PR TITLE
Add anchor-top positioning for video control buttons

### DIFF
--- a/src/widget/css.js
+++ b/src/widget/css.js
@@ -296,6 +296,11 @@ data.css = `
         z-index: 1000;
       }
 
+      .control-buttons-container.anchor-top {
+        bottom: unset;
+        top: 10px;
+      }
+
       .fullscreen-btn {
         width: 32px;
         height: 32px;

--- a/src/widget/javascript.js
+++ b/src/widget/javascript.js
@@ -497,6 +497,16 @@ function script(documents, config) {
         this.descriptionDisplay.classList.remove("shift-up");
       }
 
+      // Apply anchor-top for video content, but NOT for showAsLink documents
+      const isVideoContent = documentFormat.startsWith("video/");
+      const isShowAsLink = currentDoc && currentDoc.showAsLink;
+      
+      if (isVideoContent && !isShowAsLink) {
+        this.controlButtonsContainer.classList.add("anchor-top");
+      } else {
+        this.controlButtonsContainer.classList.remove("anchor-top");
+      }
+
       if (currentDoc.showAsLink) {
         this.descriptionDisplay.classList.add("show-as-link");
       } else {


### PR DESCRIPTION
## Summary

Adds `.anchor-top` CSS class functionality to position control buttons at the top for video content.

## Changes Made

- **CSS**: Added `.anchor-top` class in `src/widget/css.js` that sets `bottom: unset` and `top: 10px` for `.control-buttons-container`
- **JavaScript**: Integrated anchor-top logic into `showDocumentDescription()` function in `src/widget/javascript.js`
- **Logic**: Applied anchor-top for video content (`documentFormat.startsWith("video/")`) except for YouTube videos in `showAsLink` mode
- **Pattern**: Follows existing `shift-up` pattern for CSS class management

## Implementation Details

```javascript
const isVideoContent = documentFormat.startsWith("video/");
const isShowAsLink = currentDoc && currentDoc.showAsLink;

if (isVideoContent && !isShowAsLink) {
  this.controlButtonsContainer.classList.add("anchor-top");
} else {
  this.controlButtonsContainer.classList.remove("anchor-top");
}
```

## Testing

Live testing available at: https://user:7f11d2a26a86a5ebe350fe6a795f9549@github-api-app-tunnel-tbrni8by.devinapps.com

**Test Cases:**
- ✅ Video content (video/mp4, video/webm, etc.) - buttons positioned at top
- ✅ YouTube videos (not showAsLink) - buttons positioned at top  
- ✅ YouTube videos (showAsLink mode) - buttons remain at bottom
- ✅ Other formats (PDF, images, text) - buttons remain at bottom

---

Link to Devin run: https://app.devin.ai/sessions/f496b2dd643a43378f926f47f35a27d6
Requested by: yevhen.porechnyi@corezoid.com