### PR TITLE
Add allowDownload parameter support with cascading priority logic

### DIFF
--- a/src/widget/javascript.js
+++ b/src/widget/javascript.js
@@ -78,6 +78,14 @@ function script(documents, config) {
 
     shouldShowDownloadButton() {
       const currentDoc = this.documents[this.currentIndex];
+      
+      const allowDownload = currentDoc?.allowDownload !== undefined 
+        ? currentDoc.allowDownload 
+        : (this.config.allowDownload !== undefined ? this.config.allowDownload : true);
+      
+      if (!allowDownload) {
+        return false;
+      }
 
       if (currentDoc && currentDoc.showAsLink) {
         return false;


### PR DESCRIPTION
Implements allowDownload parameter with cascading priority logic:

**Features:**
- Document descriptor `allowDownload` property takes highest priority
- Falls back to global config `allowDownload` if document property not set
- Defaults to `true` if neither document nor config specify the value

**Implementation:**
- Added cascading logic to `shouldShowDownloadButton()` method
- Uses optional chaining and ternary operators for clean code
- Early return prevents download button display when `allowDownload` is false
- Maintains all existing format-based restrictions

**Usage:**
```javascript
// Hide download for specific document
{ url: "...", allowDownload: false }

// Hide download globally
config: { allowDownload: false }

// Show by default (no property needed)
{ url: "..." } // with config: {}
```

**Link to Devin run:** https://app.devin.ai/sessions/f496b2dd643a43378f926f47f35a27d6
**Requested by:** yevhen.porechnyi@corezoid.com